### PR TITLE
Payment Processor now accepts 'gateway' as key in $parameters array p…

### DIFF
--- a/src/Entities/PaymentProcessor.php
+++ b/src/Entities/PaymentProcessor.php
@@ -10,6 +10,7 @@ use EscolaLms\Payments\Events\PaymentFailed;
 use EscolaLms\Payments\Events\PaymentRequiresRedirect;
 use EscolaLms\Payments\Events\PaymentSuccess;
 use EscolaLms\Payments\Facades\PaymentGateway;
+use EscolaLms\Payments\Facades\Payments;
 use EscolaLms\Payments\Gateway\Drivers\Contracts\GatewayDriverContract;
 use EscolaLms\Payments\Models\Payment;
 use Illuminate\Http\Request;
@@ -87,7 +88,13 @@ class PaymentProcessor
 
     public function purchase(array $parameters = []): self
     {
-        $this->setPaymentDriverName($this->getPaymentDriverName());
+        $driver = $parameters['gateway'] ?? null;
+        if (!is_null($driver) && Payments::isDriverEnabled($driver)) {
+            $this->setPaymentDriverName($driver);
+        } else {
+            $this->setPaymentDriverName($this->getPaymentDriverName());
+        }
+
         $this->savePayment();
 
         $response = $this->getPaymentDriver()->purchase($this->payment, $parameters);

--- a/src/Facades/Fakes/FakeDriver.php
+++ b/src/Facades/Fakes/FakeDriver.php
@@ -2,8 +2,57 @@
 
 namespace EscolaLms\Payments\Facades\Fakes;
 
-use EscolaLms\Payments\Gateway\Drivers\FreeDriver;
+use EscolaLms\Payments\Entities\PaymentsConfig;
+use EscolaLms\Payments\Gateway\Drivers\AbstractDriver;
+use EscolaLms\Payments\Gateway\Drivers\Contracts\GatewayDriverContract;
+use EscolaLms\Payments\Gateway\Drivers\Przelewy24Driver;
+use EscolaLms\Payments\Gateway\Drivers\StripeDriver;
+use EscolaLms\Payments\Gateway\Responses\CallbackResponse;
+use EscolaLms\Payments\Gateway\Responses\NoneGatewayResponse;
+use EscolaLms\Payments\Models\Payment;
+use Illuminate\Http\Request;
+use Omnipay\Common\Message\ResponseInterface;
 
-class FakeDriver extends FreeDriver
+class FakeDriver extends AbstractDriver implements GatewayDriverContract
 {
+    protected ?string $requested_driver = null;
+
+    public function __construct(PaymentsConfig $config, ?string $requested_driver = null)
+    {
+        parent::__construct($config);
+        $this->requested_driver = $requested_driver;
+    }
+
+    public function purchase(Payment $payment, array $parameters = []): ResponseInterface
+    {
+        $this->throwExceptionIfMissingParameters($parameters);
+        return new NoneGatewayResponse();
+    }
+
+    public function callback(Request $request, array $parameters = []): CallbackResponse
+    {
+        return new CallbackResponse();
+    }
+
+    public static function requiredParameters(): array
+    {
+        return [];
+    }
+
+    protected function getRequiredParameters(): array
+    {
+        switch ($this->requested_driver) {
+            case 'stripe':
+                return StripeDriver::requiredParameters();
+            case 'przelewy24':
+                return Przelewy24Driver::requiredParameters();
+            default:
+                return self::requiredParameters();
+        }
+    }
+
+    public function getRequestedDriver(): ?string
+    {
+        return $this->requested_driver;
+    }
 }

--- a/src/Facades/Fakes/PaymentGatewayFake.php
+++ b/src/Facades/Fakes/PaymentGatewayFake.php
@@ -7,8 +7,16 @@ use EscolaLms\Payments\Facades\Fakes\FakeDriver;
 
 class PaymentGatewayFake extends GatewayManager
 {
+    protected ?string $requested_driver = null;
+
     public function driver($driver = null)
     {
-        return new FakeDriver($this->paymentsConfig);
+        $this->requested_driver = $driver;
+        return new FakeDriver($this->paymentsConfig, $driver);
+    }
+
+    public function getRequestedDriver(): ?string
+    {
+        return $this->requested_driver;
     }
 }

--- a/src/Facades/Payments.php
+++ b/src/Facades/Payments.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Facade;
  * 
  * @method static array listEnabledGateways()
  * @method static array listGatewaysWithRequiredParameters()
+ * @method static bool isDriverEnabled(string $driver)
  * 
  * @method static PaymentProcessor processPayable(Payable $payable)
  * @method static PaymentProcessor processPayment(Payment $payment)

--- a/src/Gateway/Drivers/AbstractDriver.php
+++ b/src/Gateway/Drivers/AbstractDriver.php
@@ -32,13 +32,18 @@ abstract class AbstractDriver implements GatewayDriverContract
         }
     }
 
+    protected function getRequiredParameters(): array
+    {
+        return static::requiredParameters();
+    }
+
     public function hasAllRequiredParameters(array $parameters = []): bool
     {
-        return Arr::has($parameters, static::requiredParameters());
+        return empty($this->getRequiredParameters()) || Arr::has($parameters, $this->getRequiredParameters());
     }
 
     public function missingParameters(array $parameters = []): array
     {
-        return array_filter(static::requiredParameters(), fn (string $required) => !array_key_exists($required, $parameters));
+        return array_filter($this->getRequiredParameters(), fn (string $required) => !array_key_exists($required, $parameters));
     }
 }

--- a/src/Services/Contracts/PaymentsServiceContract.php
+++ b/src/Services/Contracts/PaymentsServiceContract.php
@@ -17,6 +17,7 @@ interface PaymentsServiceContract
 
     public function listEnabledGateways(): array;
     public function listGatewaysWithRequiredParameters(): array;
+    public function isDriverEnabled(string $driver): bool;
 
     public function processPayable(Payable $payable): PaymentProcessor;
     public function processPayment(Payment $payment): PaymentProcessor;

--- a/src/Services/PaymentsService.php
+++ b/src/Services/PaymentsService.php
@@ -102,4 +102,9 @@ class PaymentsService implements PaymentsServiceContract
             ]
         ];
     }
+
+    public function isDriverEnabled(string $driver): bool
+    {
+        return array_key_exists($driver, $this->listEnabledGateways());
+    }
 }


### PR DESCRIPTION
…assed to `purchase` method. Available gateways (and their required parameters) can be checked using Payments Facade (Payments::listGatewaysWithRequiredParameters() method).